### PR TITLE
Fix invalid hashes with least possible disruptions

### DIFF
--- a/src/js/iqons.js
+++ b/src/js/iqons.js
@@ -180,6 +180,9 @@ ${ content }
             .replace('.', fullHash[5]) // Replace the dot as it cannot be parsed to int
             .substr(4, 17);
 
+        // The index 5 of `fullHash` is currently unused (index 1 of `hash`,
+        // after cutting off the first 4 elements). Iqons.svg() is not using it.
+
         // A small percentage of returned values are actually too short,
         // leading to an invalid bottom index and feature color. Adding
         // padding creates a bottom feature and accent color where no
@@ -205,7 +208,7 @@ ${ content }
         if (!!String.prototype.padEnd) return string.padEnd(maxLength, fillString);
         else {
             while (string.length < maxLength) string += fillString;
-            return string.substr(0, maxLength);
+            return string.substring(0, Math.max(string.length, maxLength));
         }
     }
 }

--- a/src/js/iqons.js
+++ b/src/js/iqons.js
@@ -169,20 +169,22 @@ ${ content }
     }
 
     static _hash(text) {
-        const hash = ('' + text
+        const fullHash = ('' + text
                 .split('')
                 .map(c => Number(c.charCodeAt(0)) + 3)
                 .reduce((a, e) => a * (1 - a) * this.__chaosHash(e), 0.5))
             .split('')
-            .reduce((a, e) => e + a, '')
-            .substr(4, 17)
-            .replace('.', '0'); // A dot cannot be parsed into an int
+            .reduce((a, e) => e + a, '');
+
+        const hash = fullHash
+            .replace('.', fullHash[5]) // Replace the dot as it cannot be parsed to int
+            .substr(4, 17);
 
         // A small percentage of returned values are actually too short,
         // leading to an invalid bottom index and feature color. Adding
-        // zeros creates a bottom feature and feature color where no
+        // padding creates a bottom feature and accent color where no
         // existed previously, thus it's not a disrupting change.
-        return Iqons._padEnd(hash, 13, '0');
+        return Iqons._padEnd(hash, 13, fullHash[5]);
     }
 
     static __chaosHash(number) {

--- a/src/js/iqons.js
+++ b/src/js/iqons.js
@@ -205,7 +205,7 @@ ${ content }
         if (!!String.prototype.padEnd) return string.padEnd(maxLength, fillString);
         else {
             while (string.length < maxLength) string += fillString;
-            return string;
+            return string.substr(0, maxLength);
         }
     }
 }

--- a/src/js/iqons.js
+++ b/src/js/iqons.js
@@ -169,13 +169,20 @@ ${ content }
     }
 
     static _hash(text) {
-        return ('' + text
+        const hash = ('' + text
                 .split('')
                 .map(c => Number(c.charCodeAt(0)) + 3)
                 .reduce((a, e) => a * (1 - a) * this.__chaosHash(e), 0.5))
             .split('')
             .reduce((a, e) => e + a, '')
-            .substr(4, 17);
+            .substr(4, 17)
+            .replace('.', '0'); // A dot cannot be parsed into an int
+
+        // A small percentage of returned values are actually too short,
+        // leading to an invalid bottom index and feature color. Adding
+        // zeros creates a bottom feature and feature color where no
+        // existed previously, thus it's not a disrupting change.
+        return Iqons._padEnd(hash, 13, '0');
     }
 
     static __chaosHash(number) {
@@ -189,6 +196,15 @@ ${ content }
 
     static _getRandomId() {
         return Math.floor(Math.random() * 256);
+    }
+
+    // Polyfill
+    static _padEnd(string, maxLength, fillString) {
+        if (!!String.prototype.padEnd) return string.padEnd(maxLength, fillString);
+        else {
+            while (string.length < maxLength) string += fillString;
+            return string;
+        }
     }
 }
 


### PR DESCRIPTION
Resolves #8.

A small percentage of returned values are actually too short, to an invalid bottom index and feature color. Adding creates a bottom feature and feature color where existed previously, thus it's not a disrupting change.

The change was tested, and does not interfere with most of the identicons. Only identicons which were missing features or colors previously are now changed (fixed).